### PR TITLE
Constants generation tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ test-full: test test-mutation
 
 build-docs:
 	docker run --rm -v $(shell pwd):/data phpdoc/phpdoc:3 -d /data/src -t ./docs
+
+generate-constants:
+	php ./tools/make-constants.php

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Wojciech\\Phlambda\\": "tests/"
+            "Tests\\Wojciech\\Phlambda\\": "tests/",
+            "Tools\\Wojciech\\Phlambda\\": "tools/"
         }
     },
     "authors": [
@@ -30,11 +31,12 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8",
         "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "infection/infection": "^0.25.5"
+        "infection/infection": "^0.25.5",
+        "nette/php-generator": "^3.6"
     }
 }

--- a/tools/make-constants.php
+++ b/tools/make-constants.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Tools\Wojciech\Phlambda;
+
+use function Wojciech\Phlambda\_;
+use function Wojciech\Phlambda\matches;
+use function Wojciech\Phlambda\startsWith;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+const target_namespace = 'Wojciech\Phlambda';
+
+$file = new \Nette\PhpGenerator\PhpFile();
+$file->addComment('This file is auto-generated.');
+$file->setStrictTypes();
+$file->addNamespace(target_namespace);
+
+$declaredFunctions = _(get_defined_functions()['user'])
+    ->filter(startsWith(strtolower(target_namespace)))
+    ->flatMap(fn (string $name) => (new \ReflectionFunction($name))->getName())
+    ->flatMap(matches('/Wojciech\\\\Phlambda\\\\\K\w+/'))
+    ->toArray();
+
+$fileContent = (string) $file;
+
+foreach ($declaredFunctions as $function) {
+    $fileContent .= sprintf('const %s = "\%s\%s"; ' . PHP_EOL, $function, target_namespace, $function);
+}
+
+file_put_contents(__DIR__ . '/../src/constants.php', $fileContent);


### PR DESCRIPTION
Because adding constants with functions names can be easily automated and is dull task
I added tool for generating those, which can be used with simple command:
`make generate-constants`
This will add file `./src/constants.php` or replace it if exists with all functions in namespace.